### PR TITLE
Fixing a typo, in implicit flow the access token was not available 

### DIFF
--- a/src/implicit-request-handler.ts
+++ b/src/implicit-request-handler.ts
@@ -234,7 +234,7 @@ export class IonicImplicitRequestHandler extends ImplicitRequestHandler {
 
     private getImplicitResponse(queryParams : StringMap): TokenResponse {
         let implicitResponseJSON : TokenResponseJson = {
-            access_token: queryParams['access_type'],
+            access_token: queryParams['access_token'],
             token_type: this.convertToTokenType(queryParams['token_type']),
             expires_in: +queryParams['expires_in'],
             refresh_token: queryParams['refresh_token'],


### PR DESCRIPTION
Seems like this was a type, i came to find this, cause i need the access_token for an api later ...