### PR TITLE
Added 'buffer' parameter to token.isValid()

### DIFF
--- a/src/ionic-auth.ts
+++ b/src/ionic-auth.ts
@@ -13,7 +13,7 @@ import { ImplicitRequestHandler, ImplicitNotifier, IMPLICIT_RESPONSE_KEY } from 
 import { ImplicitRequest, ImplicitRequestJson, ImplicitResponseType } from './implicit-request';
 
 const TOKEN_RESPONSE_KEY = "token_response";
-const AUTH_EXPIRY_BUFFER = 10 * 60;  // 10 mins in seconds
+const AUTH_EXPIRY_BUFFER = 10 * 60 * -1;  // 10 mins in seconds
 const IS_VALID_BUFFER_KEY = 'isValidBuffer';
 
 export class IonicAuth {

--- a/src/ionic-auth.ts
+++ b/src/ionic-auth.ts
@@ -13,8 +13,11 @@ import { ImplicitRequestHandler, ImplicitNotifier, IMPLICIT_RESPONSE_KEY } from 
 import { ImplicitRequest, ImplicitRequestJson, ImplicitResponseType } from './implicit-request';
 
 const TOKEN_RESPONSE_KEY = "token_response";
+const AUTH_EXPIRY_BUFFER = 10 * 60;  // 10 mins in seconds
+const IS_VALID_BUFFER_KEY = 'isValidBuffer';
 
 export class IonicAuth {
+    
     protected configuration: AuthorizationServiceConfiguration | undefined;
     protected authConfig: IAuthConfig | undefined;
 
@@ -264,7 +267,20 @@ export class IonicAuth {
         if(token == undefined)
             throw new Error("Unable To Obtain Token - No Token Available");
 
-        if(!token.isValid()){
+        // The buffer parameter passed to token.isValid().
+        let isValidBuffer = AUTH_EXPIRY_BUFFER;
+
+        const authConfig : IAuthConfig = this.getAuthConfig();
+
+        // See if a IS_VALID_BUFFER_KEY is specified in the config extras,
+        // to specify a buffer parameter for token.isValid().
+        if (authConfig.auth_extras) {
+            if (authConfig.auth_extras.hasOwnProperty(IS_VALID_BUFFER_KEY)) {
+                isValidBuffer = parseInt(authConfig.auth_extras[IS_VALID_BUFFER_KEY]);
+            }
+        }
+
+        if(!token.isValid(isValidBuffer)){
             token = await this.requestNewToken(token);
         }
 

--- a/src/ionic-auth.ts
+++ b/src/ionic-auth.ts
@@ -276,7 +276,7 @@ export class IonicAuth {
         // to specify a buffer parameter for token.isValid().
         if (authConfig.auth_extras) {
             if (authConfig.auth_extras.hasOwnProperty(IS_VALID_BUFFER_KEY)) {
-                isValidBuffer = parseInt(authConfig.auth_extras[IS_VALID_BUFFER_KEY]);
+                isValidBuffer = parseInt(authConfig.auth_extras[IS_VALID_BUFFER_KEY], 10);
             }
         }
 


### PR DESCRIPTION
The base [@openid/appauth/token_response.ts](https://github.com/openid/AppAuth-JS/blob/master/src/token_response.ts) allows a buffer parameter to be passed to isValid(), which is a buffer of a number of seconds leeway when checking token expiry.

I have added the ability to set a 'isValidBuffer' key in IAuthConfig.auth_extras, which if present will be passed to token.isValid(). This allows you to specify whatever buffer value you want for validity checking, instead of relying on the @openid default value.

E.g.
```
this.authConfig = {
    .......,
    auth_extras: {
        'isValidBuffer': '-5'
    }
};
```