### PR TITLE
Removed window.close() in DefaultBrowser, added an explanatory comment.

### DIFF
--- a/src/auth-browser.ts
+++ b/src/auth-browser.ts
@@ -20,6 +20,7 @@ export class DefaultBrowser extends Browser {
     }
 
     public closeWindow(): void {
-        window.close();
+        // Invoking window.close() is not desired. It will either be ignored (most of the time),
+        // or it will close the current browser tab if this site was opened via a "_blank" target.
     }
 }


### PR DESCRIPTION
window.close() should never be called after a login or logout when using the DefaultBrowser.  This behavior is desired when using one of the derived browsers, but not the default.

This PR fixes issue #51 .  It was tested locally.