### PR TITLE
use LogoutRedirectUri if endSessionEndpoint is undefined

### DIFF
--- a/src/end-session-request-handler.ts
+++ b/src/end-session-request-handler.ts
@@ -26,7 +26,7 @@ export class IonicEndSessionHandler implements EndSessionHandler {
       };
   
       let query = this.utils.stringify(requestMap);
-      let baseUrl = configuration.endSessionEndpoint;
+      let baseUrl = configuration.endSessionEndpoint ? configuration.endSessionEndpoint: request.postLogoutRedirectURI;
       let url = `${baseUrl}?${query}`;
       return url;
     }


### PR DESCRIPTION
My Google configuration does not have an endSessionEndpoint (undefined). 
The buildRequestUrl function just used "undefined" as baseUrl. 
Instead of using "undefined" the function now uses the postLogoutRedirectURI as base URL which enables manual signOut handling.