### PR TITLE
CordovaRequester: HTTP serializer fix

### DIFF
--- a/lib/cordova/cordova-requestor.d.ts
+++ b/lib/cordova/cordova-requestor.d.ts
@@ -9,6 +9,7 @@ export interface XhrSettings {
 export declare class CordovaRequestor extends Requestor {
     constructor();
     xhr<T>(settings: XhrSettings): Promise<T>;
+    private makeRequest;
     private get;
     private post;
     private put;

--- a/lib/cordova/cordova-requestor.js
+++ b/lib/cordova/cordova-requestor.js
@@ -6,7 +6,6 @@ import { HTTP } from '@ionic-native/http';
 // cordova-plugin-advanced-http
 export class CordovaRequestor extends Requestor {
     constructor() {
-        CordovaDocument.ready(() => HTTP.setDataSerializer('utf8'));
         super();
     }
     xhr(settings) {
@@ -14,14 +13,23 @@ export class CordovaRequestor extends Requestor {
             if (!settings.method)
                 settings.method = "GET";
             yield CordovaDocument.ready();
+            const previousSerializerType = HTTP.getDataSerializer();
+            HTTP.setDataSerializer('utf8');
+            const response = yield this.makeRequest(settings);
+            HTTP.setDataSerializer(previousSerializerType);
+            return response;
+        });
+    }
+    makeRequest(settings) {
+        return __awaiter(this, void 0, void 0, function* () {
             switch (settings.method) {
-                case "GET":
+                case 'GET':
                     return this.get(settings.url, settings.headers);
-                case "POST":
+                case 'POST':
                     return this.post(settings.url, settings.data, settings.headers);
-                case "PUT":
+                case 'PUT':
                     return this.put(settings.url, settings.data, settings.headers);
-                case "DELETE":
+                case 'DELETE':
                     return this.delete(settings.url, settings.headers);
             }
         });

--- a/src/cordova/cordova-requestor.ts
+++ b/src/cordova/cordova-requestor.ts
@@ -10,30 +10,41 @@ export interface XhrSettings {
     headers?: any// {key : string, value: any}
 }
 
+type SerializerType = 'json' | 'urlencoded' | 'utf8' | 'multipart' | 'raw';
+
 // REQUIRES CORDOVA PLUGINS
 // cordova-plugin-advanced-http
 export class CordovaRequestor extends Requestor {
 
     constructor(){
-        CordovaDocument.ready(() => HTTP.setDataSerializer('utf8'));
         super();
     }
 
     public async xhr<T>(settings: XhrSettings) : Promise<T> {
-        if(!settings.method)   
+        if(!settings.method)
             settings.method = "GET";
 
         await CordovaDocument.ready();
 
-        switch(settings.method){
-            case "GET":
-                return this.get(settings.url, settings.headers);
-            case "POST":
-                return this.post(settings.url, settings.data, settings.headers);
-            case "PUT":
-                return this.put(settings.url, settings.data, settings.headers);
-            case "DELETE":
-                return this.delete(settings.url, settings.headers);
+        const previousSerializerType = HTTP.getDataSerializer() as SerializerType;
+        HTTP.setDataSerializer('utf8')
+
+        const response = await this.makeRequest<T>(settings);
+
+        HTTP.setDataSerializer(previousSerializerType);
+        return response;
+    }
+
+    private async makeRequest<T>(settings: XhrSettings): Promise<T> {
+        switch (settings.method) {
+        case 'GET':
+            return this.get(settings.url, settings.headers);
+        case 'POST':
+            return this.post(settings.url, settings.data, settings.headers);
+        case 'PUT':
+            return this.put(settings.url, settings.data, settings.headers);
+        case 'DELETE':
+            return this.delete(settings.url, settings.headers);
         }
     }
 


### PR DESCRIPTION
Fix for #103 
Sets the DataSerializer to 'utf8' before each HTTP request.
Also saves the current DataSerializer type and restores it after each call.