### PR TITLE
Replace deprecated @ionic-native plugins with @awesome-cordova-plugins

### DIFF
--- a/lib/cordova/cordova-browser.js
+++ b/lib/cordova/cordova-browser.js
@@ -1,8 +1,8 @@
 import { __awaiter } from "tslib";
 import { CordovaDocument } from './cordova-document';
 import { Browser } from '../auth-browser';
-import { SafariViewController } from '@ionic-native/safari-view-controller';
-import { InAppBrowser } from '@ionic-native/in-app-browser';
+import { SafariViewController } from '@awesome-cordova-plugins/safari-view-controller';
+import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser';
 // REQUIRES CORDOVA PLUGINS
 // cordova-plugin-safariviewcontroller
 // cordova-plugin-customurlscheme

--- a/lib/cordova/cordova-requestor.js
+++ b/lib/cordova/cordova-requestor.js
@@ -1,7 +1,7 @@
 import { __awaiter } from "tslib";
 import { CordovaDocument } from './cordova-document';
 import { Requestor } from '@openid/appauth';
-import { HTTP } from '@ionic-native/http';
+import { HTTP } from '@awesome-cordova-plugins/http';
 // REQUIRES CORDOVA PLUGINS
 // cordova-plugin-advanced-http
 export class CordovaRequestor extends Requestor {

--- a/lib/cordova/cordova-secure-storage.d.ts
+++ b/lib/cordova/cordova-secure-storage.d.ts
@@ -1,5 +1,5 @@
 import { StorageBackend } from '@openid/appauth';
-import { SecureStorageObject } from '@ionic-native/secure-storage';
+import { SecureStorageObject } from '@awesome-cordova-plugins/secure-storage';
 export declare class CordovaSecureStorage extends StorageBackend {
     private localData;
     private KEYSTORE;

--- a/lib/cordova/cordova-secure-storage.js
+++ b/lib/cordova/cordova-secure-storage.js
@@ -1,7 +1,7 @@
 import { __awaiter } from "tslib";
 import { CordovaDocument } from './cordova-document';
 import { StorageBackend } from '@openid/appauth';
-import { SecureStorage } from '@ionic-native/secure-storage';
+import { SecureStorage } from '@awesome-cordova-plugins/secure-storage';
 // REQUIRES CORDOVA PLUGINS
 // cordova-plugin-secure-storage
 export class CordovaSecureStorage extends StorageBackend {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,19 +15,19 @@
       },
       "devDependencies": {
         "@types/node": "^18.8.3",
-        "@typescript-eslint/eslint-plugin": "^5.39.0",
-        "@typescript-eslint/parser": "^5.39.0",
-        "eslint": "^8.24.0",
+        "@typescript-eslint/eslint-plugin": "^5.40.0",
+        "@typescript-eslint/parser": "^5.40.0",
+        "eslint": "^8.25.0",
         "husky": "^8.0.1",
         "rxjs": "^7.5.7",
         "typescript": "^4.8.4"
       },
       "optionalDependencies": {
-        "@awesome-cordova-plugins/core": "^5.45.0",
-        "@awesome-cordova-plugins/http": "^5.45.0",
-        "@awesome-cordova-plugins/in-app-browser": "^5.45.0",
-        "@awesome-cordova-plugins/safari-view-controller": "^5.45.0",
-        "@awesome-cordova-plugins/secure-storage": "^5.45.0",
+        "@awesome-cordova-plugins/core": "^5.46.0",
+        "@awesome-cordova-plugins/http": "^5.46.0",
+        "@awesome-cordova-plugins/in-app-browser": "^5.46.0",
+        "@awesome-cordova-plugins/safari-view-controller": "^5.46.0",
+        "@awesome-cordova-plugins/secure-storage": "^5.46.0",
         "@capacitor/browser": "^4.0.1",
         "@capacitor/core": "^4.3.0",
         "@capacitor/preferences": "^4.0.1",
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@awesome-cordova-plugins/core": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/core/-/core-5.45.0.tgz",
-      "integrity": "sha512-VrFNy6KLu3yyIKX3+6knUTDfSy59MPWUDni31ypGIQyxZv0eInuAgy3D4dhEdSbTkCIRyF40u4CJk4bN5zUYzQ==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/core/-/core-5.46.0.tgz",
+      "integrity": "sha512-EkCTsS9sE4lXzPbKZonn7PEzoF1/vvhsJDnIyqP3FObBqb8fjqhEz4r7z4iNRNHel4Mq9bICzI5J/3vQ+jbWVw==",
       "optional": true,
       "dependencies": {
         "@types/cordova": "latest"
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@awesome-cordova-plugins/http": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/http/-/http-5.45.0.tgz",
-      "integrity": "sha512-8KCdYt9MZxMHSa6m5HKD9zso62al0PxYjg7LbvKP4qJy63C8ZecG8DryUSmE3sUtkusrgdENt1pCK8N0Pmi1hw==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/http/-/http-5.46.0.tgz",
+      "integrity": "sha512-F+E5nlYHINJmXcVwTK21FRAm0ZSqrhXIkiMbbj5uM7a0lzr4V9GpB6qJmKrE8wj+uP7bKpOTf890PcY+6fZ+NA==",
       "optional": true,
       "dependencies": {
         "@types/cordova": "latest"
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@awesome-cordova-plugins/in-app-browser": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/in-app-browser/-/in-app-browser-5.45.0.tgz",
-      "integrity": "sha512-nxuYTurkQujKF/KOyB1q3SpRGvjbshWPjM6TK0Up9iOheoo3LOLtc68fOOuzYWtLPbDgB4LMmJWkPUFkLC1sIQ==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/in-app-browser/-/in-app-browser-5.46.0.tgz",
+      "integrity": "sha512-pjy1fH85gpO8/lyl2dd2TjqbNBkMm8eeAXqRQ+E6d6acAvsKwR0WKOWBkhRQhO7yd4rZXUBcQnnSQf2zU1uTrg==",
       "optional": true,
       "dependencies": {
         "@types/cordova": "latest"
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@awesome-cordova-plugins/safari-view-controller": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/safari-view-controller/-/safari-view-controller-5.45.0.tgz",
-      "integrity": "sha512-DwfvBfmxD4v+EgmT/LMjjMSHjR1OuqmdlZK/kXcgI/NjTP7YmeFcX2S/pK/wdKnAYbEXHVXUiYhQoaCKCS8cQQ==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/safari-view-controller/-/safari-view-controller-5.46.0.tgz",
+      "integrity": "sha512-UUk3uz/FF09UKRDHU63U1khN75yk/nzt7JbgeFzbO2dXmm8I57Te7AnK+ixx5zmA21dgznhS7NSD8d0a1VV4fQ==",
       "optional": true,
       "dependencies": {
         "@types/cordova": "latest"
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@awesome-cordova-plugins/secure-storage": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/secure-storage/-/secure-storage-5.45.0.tgz",
-      "integrity": "sha512-aBW5sfHiVFn1yodwe20UQO6v7iBHsH/w0soBiJSoRf2eBG2SMj2ax4ZqdoZpV3/E+N/ARgZJV2NS6DJOnTetsg==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/secure-storage/-/secure-storage-5.46.0.tgz",
+      "integrity": "sha512-SJZJ+jemDeOnWcuaemXlvDXEfjNg+oYhv2DPOzD3pEIDb63vpOoC6MPLfPMWnfcs4k6kJn25RHl6MlzRrzv24w==",
       "optional": true,
       "dependencies": {
         "@types/cordova": "latest"
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -164,16 +164,6 @@
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-      "dev": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -289,14 +279,14 @@
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-      "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.0.tgz",
+      "integrity": "sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/type-utils": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/type-utils": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
@@ -321,14 +311,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
-      "integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.0.tgz",
+      "integrity": "sha512-Ah5gqyX2ySkiuYeOIDg7ap51/b63QgWZA7w6AHtFrag7aH0lRQPbLzUjk0c9o5/KZ6JRkTTDKShL4AUrQa6/hw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -348,13 +338,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
-      "integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz",
+      "integrity": "sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0"
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -365,13 +355,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-      "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.0.tgz",
+      "integrity": "sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -392,9 +382,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-      "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
+      "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -405,13 +395,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-      "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
+      "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -432,17 +422,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
-      "integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.0.tgz",
+      "integrity": "sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -456,12 +447,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-      "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
+      "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/types": "5.40.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -751,14 +742,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.2",
+        "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.10.5",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -1921,45 +1911,45 @@
   },
   "dependencies": {
     "@awesome-cordova-plugins/core": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/core/-/core-5.45.0.tgz",
-      "integrity": "sha512-VrFNy6KLu3yyIKX3+6knUTDfSy59MPWUDni31ypGIQyxZv0eInuAgy3D4dhEdSbTkCIRyF40u4CJk4bN5zUYzQ==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/core/-/core-5.46.0.tgz",
+      "integrity": "sha512-EkCTsS9sE4lXzPbKZonn7PEzoF1/vvhsJDnIyqP3FObBqb8fjqhEz4r7z4iNRNHel4Mq9bICzI5J/3vQ+jbWVw==",
       "optional": true,
       "requires": {
         "@types/cordova": "latest"
       }
     },
     "@awesome-cordova-plugins/http": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/http/-/http-5.45.0.tgz",
-      "integrity": "sha512-8KCdYt9MZxMHSa6m5HKD9zso62al0PxYjg7LbvKP4qJy63C8ZecG8DryUSmE3sUtkusrgdENt1pCK8N0Pmi1hw==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/http/-/http-5.46.0.tgz",
+      "integrity": "sha512-F+E5nlYHINJmXcVwTK21FRAm0ZSqrhXIkiMbbj5uM7a0lzr4V9GpB6qJmKrE8wj+uP7bKpOTf890PcY+6fZ+NA==",
       "optional": true,
       "requires": {
         "@types/cordova": "latest"
       }
     },
     "@awesome-cordova-plugins/in-app-browser": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/in-app-browser/-/in-app-browser-5.45.0.tgz",
-      "integrity": "sha512-nxuYTurkQujKF/KOyB1q3SpRGvjbshWPjM6TK0Up9iOheoo3LOLtc68fOOuzYWtLPbDgB4LMmJWkPUFkLC1sIQ==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/in-app-browser/-/in-app-browser-5.46.0.tgz",
+      "integrity": "sha512-pjy1fH85gpO8/lyl2dd2TjqbNBkMm8eeAXqRQ+E6d6acAvsKwR0WKOWBkhRQhO7yd4rZXUBcQnnSQf2zU1uTrg==",
       "optional": true,
       "requires": {
         "@types/cordova": "latest"
       }
     },
     "@awesome-cordova-plugins/safari-view-controller": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/safari-view-controller/-/safari-view-controller-5.45.0.tgz",
-      "integrity": "sha512-DwfvBfmxD4v+EgmT/LMjjMSHjR1OuqmdlZK/kXcgI/NjTP7YmeFcX2S/pK/wdKnAYbEXHVXUiYhQoaCKCS8cQQ==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/safari-view-controller/-/safari-view-controller-5.46.0.tgz",
+      "integrity": "sha512-UUk3uz/FF09UKRDHU63U1khN75yk/nzt7JbgeFzbO2dXmm8I57Te7AnK+ixx5zmA21dgznhS7NSD8d0a1VV4fQ==",
       "optional": true,
       "requires": {
         "@types/cordova": "latest"
       }
     },
     "@awesome-cordova-plugins/secure-storage": {
-      "version": "5.45.0",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/secure-storage/-/secure-storage-5.45.0.tgz",
-      "integrity": "sha512-aBW5sfHiVFn1yodwe20UQO6v7iBHsH/w0soBiJSoRf2eBG2SMj2ax4ZqdoZpV3/E+N/ARgZJV2NS6DJOnTetsg==",
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/secure-storage/-/secure-storage-5.46.0.tgz",
+      "integrity": "sha512-SJZJ+jemDeOnWcuaemXlvDXEfjNg+oYhv2DPOzD3pEIDb63vpOoC6MPLfPMWnfcs4k6kJn25RHl6MlzRrzv24w==",
       "optional": true,
       "requires": {
         "@types/cordova": "latest"
@@ -1989,9 +1979,9 @@
       "requires": {}
     },
     "@eslint/eslintrc": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
-      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
+      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -2015,12 +2005,6 @@
         "debug": "^4.1.1",
         "minimatch": "^3.0.4"
       }
-    },
-    "@humanwhocodes/gitignore-to-minimatch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-      "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
-      "dev": true
     },
     "@humanwhocodes/module-importer": {
       "version": "1.0.1",
@@ -2119,14 +2103,14 @@
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-      "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.0.tgz",
+      "integrity": "sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/type-utils": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/type-utils": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
@@ -2135,53 +2119,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
-      "integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.40.0.tgz",
+      "integrity": "sha512-Ah5gqyX2ySkiuYeOIDg7ap51/b63QgWZA7w6AHtFrag7aH0lRQPbLzUjk0c9o5/KZ6JRkTTDKShL4AUrQa6/hw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
-      "integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz",
+      "integrity": "sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0"
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-      "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.0.tgz",
+      "integrity": "sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-      "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
+      "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-      "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
+      "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2190,26 +2174,27 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
-      "integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.0.tgz",
+      "integrity": "sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-      "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
+      "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/types": "5.40.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -2408,14 +2393,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
-      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.25.0.tgz",
+      "integrity": "sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.2",
+        "@eslint/eslintrc": "^1.3.3",
         "@humanwhocodes/config-array": "^0.10.5",
-        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,27 +14,92 @@
         "tslib": "^2.4.0"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.36.1",
-        "@typescript-eslint/parser": "^5.36.1",
-        "eslint": "^8.23.0",
+        "@types/node": "^18.8.3",
+        "@typescript-eslint/eslint-plugin": "^5.39.0",
+        "@typescript-eslint/parser": "^5.39.0",
+        "eslint": "^8.24.0",
         "husky": "^8.0.1",
-        "rxjs": "^6.6.7",
-        "typescript": "^4.8.2"
+        "rxjs": "^7.5.7",
+        "typescript": "^4.8.4"
       },
       "optionalDependencies": {
+        "@awesome-cordova-plugins/core": "^5.45.0",
+        "@awesome-cordova-plugins/http": "^5.45.0",
+        "@awesome-cordova-plugins/in-app-browser": "^5.45.0",
+        "@awesome-cordova-plugins/safari-view-controller": "^5.45.0",
+        "@awesome-cordova-plugins/secure-storage": "^5.45.0",
         "@capacitor/browser": "^4.0.1",
-        "@capacitor/core": "^4.1.0",
+        "@capacitor/core": "^4.3.0",
         "@capacitor/preferences": "^4.0.1",
-        "@ionic-native/core": "^5.36.0",
-        "@ionic-native/http": "^5.36.0",
-        "@ionic-native/in-app-browser": "^5.36.0",
-        "@ionic-native/safari-view-controller": "^5.36.0",
-        "@ionic-native/secure-storage": "^5.36.0",
         "@ionic/storage": "^3.0.6",
         "capacitor-secure-storage-plugin": "^0.8.0"
       },
       "peerDependencies": {
-        "rxjs": "^6.6.7"
+        "rxjs": "^6.6.7 || ^7.5.7"
+      }
+    },
+    "node_modules/@awesome-cordova-plugins/core": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/core/-/core-5.45.0.tgz",
+      "integrity": "sha512-VrFNy6KLu3yyIKX3+6knUTDfSy59MPWUDni31ypGIQyxZv0eInuAgy3D4dhEdSbTkCIRyF40u4CJk4bN5zUYzQ==",
+      "optional": true,
+      "dependencies": {
+        "@types/cordova": "latest"
+      },
+      "peerDependencies": {
+        "rxjs": "^5.5.0 || ^6.5.0 || ^7.3.0"
+      }
+    },
+    "node_modules/@awesome-cordova-plugins/http": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/http/-/http-5.45.0.tgz",
+      "integrity": "sha512-8KCdYt9MZxMHSa6m5HKD9zso62al0PxYjg7LbvKP4qJy63C8ZecG8DryUSmE3sUtkusrgdENt1pCK8N0Pmi1hw==",
+      "optional": true,
+      "dependencies": {
+        "@types/cordova": "latest"
+      },
+      "peerDependencies": {
+        "@awesome-cordova-plugins/core": "^5.1.0",
+        "rxjs": "^5.5.0 || ^6.5.0 || ^7.3.0"
+      }
+    },
+    "node_modules/@awesome-cordova-plugins/in-app-browser": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/in-app-browser/-/in-app-browser-5.45.0.tgz",
+      "integrity": "sha512-nxuYTurkQujKF/KOyB1q3SpRGvjbshWPjM6TK0Up9iOheoo3LOLtc68fOOuzYWtLPbDgB4LMmJWkPUFkLC1sIQ==",
+      "optional": true,
+      "dependencies": {
+        "@types/cordova": "latest"
+      },
+      "peerDependencies": {
+        "@awesome-cordova-plugins/core": "^5.1.0",
+        "rxjs": "^5.5.0 || ^6.5.0 || ^7.3.0"
+      }
+    },
+    "node_modules/@awesome-cordova-plugins/safari-view-controller": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/safari-view-controller/-/safari-view-controller-5.45.0.tgz",
+      "integrity": "sha512-DwfvBfmxD4v+EgmT/LMjjMSHjR1OuqmdlZK/kXcgI/NjTP7YmeFcX2S/pK/wdKnAYbEXHVXUiYhQoaCKCS8cQQ==",
+      "optional": true,
+      "dependencies": {
+        "@types/cordova": "latest"
+      },
+      "peerDependencies": {
+        "@awesome-cordova-plugins/core": "^5.1.0",
+        "rxjs": "^5.5.0 || ^6.5.0 || ^7.3.0"
+      }
+    },
+    "node_modules/@awesome-cordova-plugins/secure-storage": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/secure-storage/-/secure-storage-5.45.0.tgz",
+      "integrity": "sha512-aBW5sfHiVFn1yodwe20UQO6v7iBHsH/w0soBiJSoRf2eBG2SMj2ax4ZqdoZpV3/E+N/ARgZJV2NS6DJOnTetsg==",
+      "optional": true,
+      "dependencies": {
+        "@types/cordova": "latest"
+      },
+      "peerDependencies": {
+        "@awesome-cordova-plugins/core": "^5.1.0",
+        "rxjs": "^5.5.0 || ^6.5.0 || ^7.3.0"
       }
     },
     "node_modules/@capacitor/browser": {
@@ -47,9 +112,9 @@
       }
     },
     "node_modules/@capacitor/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-kHKn6693Yt9TWfuJ0Q+fyxYCpYAvVMKdu3t500seMEfdgNlF6BGaX5GbOnXkU4cnM9p+sIhRiwXv8Iqwm0E+NA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-4.3.0.tgz",
+      "integrity": "sha512-zb225feaiHYcttHqw7SnKVj9gjOh3yoM2ol0Efky4kd80qZvqPHt7nRI1XZmGUKid5j3AVggULd5rRke5OEOXQ==",
       "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -65,9 +130,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -88,9 +153,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -129,70 +194,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
-    },
-    "node_modules/@ionic-native/core": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/core/-/core-5.36.0.tgz",
-      "integrity": "sha512-lOrkktadlKYbYf1LrDyAtsu1JnQ0oCCdkOU7iHQ8oXnNOkMwobFfD2m62F1CoOr0u9LIkpYnZSPjng8lZbmbNw==",
-      "optional": true,
-      "dependencies": {
-        "@types/cordova": "latest"
-      },
-      "peerDependencies": {
-        "rxjs": "^5.5.0 || ^6.5.0"
-      }
-    },
-    "node_modules/@ionic-native/http": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/http/-/http-5.36.0.tgz",
-      "integrity": "sha512-3t7UhcqNxZuIX+HXuydlaDfA9AwDXiRFGs9GsHpJnXMTfbeKUcwzp0amqblrLslDA9tNfqSmJyFZFaMX6CRrog==",
-      "optional": true,
-      "dependencies": {
-        "@types/cordova": "latest"
-      },
-      "peerDependencies": {
-        "@ionic-native/core": "^5.1.0",
-        "rxjs": "^5.5.0 || ^6.5.0"
-      }
-    },
-    "node_modules/@ionic-native/in-app-browser": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/in-app-browser/-/in-app-browser-5.36.0.tgz",
-      "integrity": "sha512-tX/FBT0jpkgEefZ8iorv5eDKfgP/ExbYr1AWg6okORQ0dwLfXsD5KDJgKHN9GFZvyuLNeaLpC1mN7CvwvLvmgA==",
-      "optional": true,
-      "dependencies": {
-        "@types/cordova": "latest"
-      },
-      "peerDependencies": {
-        "@ionic-native/core": "^5.1.0",
-        "rxjs": "^5.5.0 || ^6.5.0"
-      }
-    },
-    "node_modules/@ionic-native/safari-view-controller": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/safari-view-controller/-/safari-view-controller-5.36.0.tgz",
-      "integrity": "sha512-pvqnzro3bBZ0bQOMjBRKhmjHDaLKfDS75QY7uqe9UzjufMnHtBUUWgMvTuL7MsjTXRj8iRhe1wnUv8aBkz4SVA==",
-      "optional": true,
-      "dependencies": {
-        "@types/cordova": "latest"
-      },
-      "peerDependencies": {
-        "@ionic-native/core": "^5.1.0",
-        "rxjs": "^5.5.0 || ^6.5.0"
-      }
-    },
-    "node_modules/@ionic-native/secure-storage": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/secure-storage/-/secure-storage-5.36.0.tgz",
-      "integrity": "sha512-8wRH0bUMvJVnEu052cA1gi10cYJzNWMa67uRavay2UlDA5gDzOkUl5YsvWfg3BP6UW8ZQG/YDVIyzRWSp3Gevg==",
-      "optional": true,
-      "dependencies": {
-        "@types/cordova": "latest"
-      },
-      "peerDependencies": {
-        "@ionic-native/core": "^5.1.0",
-        "rxjs": "^5.5.0 || ^6.5.0"
-      }
     },
     "node_modules/@ionic/storage": {
       "version": "3.0.6",
@@ -276,22 +277,27 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "18.8.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
+      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==",
+      "dev": true
+    },
     "node_modules/@types/sizzle": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz",
-      "integrity": "sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
+      "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/type-utils": "5.37.0",
-        "@typescript-eslint/utils": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.39.0",
+        "@typescript-eslint/type-utils": "5.39.0",
+        "@typescript-eslint/utils": "5.39.0",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
@@ -315,14 +321,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.37.0.tgz",
-      "integrity": "sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
+      "integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.39.0",
+        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.39.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -342,13 +348,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
-      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
+      "integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/visitor-keys": "5.37.0"
+        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/visitor-keys": "5.39.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -359,13 +365,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
-      "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
+      "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.37.0",
-        "@typescript-eslint/utils": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/utils": "5.39.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -386,9 +392,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
+      "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -399,13 +405,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
+      "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/visitor-keys": "5.37.0",
+        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/visitor-keys": "5.39.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -426,15 +432,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
-      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
+      "integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.39.0",
+        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.39.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -450,12 +456,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
+      "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/types": "5.39.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -745,13 +751,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.1",
-        "@humanwhocodes/config-array": "^0.10.4",
+        "@eslint/eslintrc": "^1.3.2",
+        "@humanwhocodes/config-array": "^0.10.5",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
@@ -769,7 +775,6 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -778,6 +783,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -955,9 +961,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1063,9 +1069,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
@@ -1098,12 +1104,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
     "node_modules/glob": {
@@ -1298,6 +1298,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "node_modules/js-yaml": {
@@ -1685,27 +1691,18 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "devOptional": true,
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
     },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "devOptional": true
-    },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1852,9 +1849,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1923,6 +1920,51 @@
     }
   },
   "dependencies": {
+    "@awesome-cordova-plugins/core": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/core/-/core-5.45.0.tgz",
+      "integrity": "sha512-VrFNy6KLu3yyIKX3+6knUTDfSy59MPWUDni31ypGIQyxZv0eInuAgy3D4dhEdSbTkCIRyF40u4CJk4bN5zUYzQ==",
+      "optional": true,
+      "requires": {
+        "@types/cordova": "latest"
+      }
+    },
+    "@awesome-cordova-plugins/http": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/http/-/http-5.45.0.tgz",
+      "integrity": "sha512-8KCdYt9MZxMHSa6m5HKD9zso62al0PxYjg7LbvKP4qJy63C8ZecG8DryUSmE3sUtkusrgdENt1pCK8N0Pmi1hw==",
+      "optional": true,
+      "requires": {
+        "@types/cordova": "latest"
+      }
+    },
+    "@awesome-cordova-plugins/in-app-browser": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/in-app-browser/-/in-app-browser-5.45.0.tgz",
+      "integrity": "sha512-nxuYTurkQujKF/KOyB1q3SpRGvjbshWPjM6TK0Up9iOheoo3LOLtc68fOOuzYWtLPbDgB4LMmJWkPUFkLC1sIQ==",
+      "optional": true,
+      "requires": {
+        "@types/cordova": "latest"
+      }
+    },
+    "@awesome-cordova-plugins/safari-view-controller": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/safari-view-controller/-/safari-view-controller-5.45.0.tgz",
+      "integrity": "sha512-DwfvBfmxD4v+EgmT/LMjjMSHjR1OuqmdlZK/kXcgI/NjTP7YmeFcX2S/pK/wdKnAYbEXHVXUiYhQoaCKCS8cQQ==",
+      "optional": true,
+      "requires": {
+        "@types/cordova": "latest"
+      }
+    },
+    "@awesome-cordova-plugins/secure-storage": {
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/secure-storage/-/secure-storage-5.45.0.tgz",
+      "integrity": "sha512-aBW5sfHiVFn1yodwe20UQO6v7iBHsH/w0soBiJSoRf2eBG2SMj2ax4ZqdoZpV3/E+N/ARgZJV2NS6DJOnTetsg==",
+      "optional": true,
+      "requires": {
+        "@types/cordova": "latest"
+      }
+    },
     "@capacitor/browser": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-4.0.1.tgz",
@@ -1931,9 +1973,9 @@
       "requires": {}
     },
     "@capacitor/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-kHKn6693Yt9TWfuJ0Q+fyxYCpYAvVMKdu3t500seMEfdgNlF6BGaX5GbOnXkU4cnM9p+sIhRiwXv8Iqwm0E+NA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-4.3.0.tgz",
+      "integrity": "sha512-zb225feaiHYcttHqw7SnKVj9gjOh3yoM2ol0Efky4kd80qZvqPHt7nRI1XZmGUKid5j3AVggULd5rRke5OEOXQ==",
       "optional": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -1947,9 +1989,9 @@
       "requires": {}
     },
     "@eslint/eslintrc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.1.tgz",
-      "integrity": "sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
+      "integrity": "sha512-AXYd23w1S/bv3fTs3Lz0vjiYemS08jWkI3hYyS9I1ry+0f+Yjs1wm+sU0BS8qDOPrBIkp4qHYC16I8uVtpLajQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -1964,9 +2006,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
-      "integrity": "sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.7.tgz",
+      "integrity": "sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -1991,51 +2033,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
-    },
-    "@ionic-native/core": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/core/-/core-5.36.0.tgz",
-      "integrity": "sha512-lOrkktadlKYbYf1LrDyAtsu1JnQ0oCCdkOU7iHQ8oXnNOkMwobFfD2m62F1CoOr0u9LIkpYnZSPjng8lZbmbNw==",
-      "optional": true,
-      "requires": {
-        "@types/cordova": "latest"
-      }
-    },
-    "@ionic-native/http": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/http/-/http-5.36.0.tgz",
-      "integrity": "sha512-3t7UhcqNxZuIX+HXuydlaDfA9AwDXiRFGs9GsHpJnXMTfbeKUcwzp0amqblrLslDA9tNfqSmJyFZFaMX6CRrog==",
-      "optional": true,
-      "requires": {
-        "@types/cordova": "latest"
-      }
-    },
-    "@ionic-native/in-app-browser": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/in-app-browser/-/in-app-browser-5.36.0.tgz",
-      "integrity": "sha512-tX/FBT0jpkgEefZ8iorv5eDKfgP/ExbYr1AWg6okORQ0dwLfXsD5KDJgKHN9GFZvyuLNeaLpC1mN7CvwvLvmgA==",
-      "optional": true,
-      "requires": {
-        "@types/cordova": "latest"
-      }
-    },
-    "@ionic-native/safari-view-controller": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/safari-view-controller/-/safari-view-controller-5.36.0.tgz",
-      "integrity": "sha512-pvqnzro3bBZ0bQOMjBRKhmjHDaLKfDS75QY7uqe9UzjufMnHtBUUWgMvTuL7MsjTXRj8iRhe1wnUv8aBkz4SVA==",
-      "optional": true,
-      "requires": {
-        "@types/cordova": "latest"
-      }
-    },
-    "@ionic-native/secure-storage": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/@ionic-native/secure-storage/-/secure-storage-5.36.0.tgz",
-      "integrity": "sha512-8wRH0bUMvJVnEu052cA1gi10cYJzNWMa67uRavay2UlDA5gDzOkUl5YsvWfg3BP6UW8ZQG/YDVIyzRWSp3Gevg==",
-      "optional": true,
-      "requires": {
-        "@types/cordova": "latest"
-      }
     },
     "@ionic/storage": {
       "version": "3.0.6",
@@ -2110,22 +2107,27 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "18.8.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
+      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==",
+      "dev": true
+    },
     "@types/sizzle": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.37.0.tgz",
-      "integrity": "sha512-Fde6W0IafXktz1UlnhGkrrmnnGpAo1kyX7dnyHHVrmwJOn72Oqm3eYtddrpOwwel2W8PAK9F3pIL5S+lfoM0og==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
+      "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/type-utils": "5.37.0",
-        "@typescript-eslint/utils": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.39.0",
+        "@typescript-eslint/type-utils": "5.39.0",
+        "@typescript-eslint/utils": "5.39.0",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
@@ -2133,53 +2135,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.37.0.tgz",
-      "integrity": "sha512-01VzI/ipYKuaG5PkE5+qyJ6m02fVALmMPY3Qq5BHflDx3y4VobbLdHQkSMg9VPRS4KdNt4oYTMaomFoHonBGAw==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.39.0.tgz",
+      "integrity": "sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.39.0",
+        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.39.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.37.0.tgz",
-      "integrity": "sha512-F67MqrmSXGd/eZnujjtkPgBQzgespu/iCZ+54Ok9X5tALb9L2v3G+QBSoWkXG0p3lcTJsL+iXz5eLUEdSiJU9Q==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
+      "integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/visitor-keys": "5.37.0"
+        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/visitor-keys": "5.39.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.37.0.tgz",
-      "integrity": "sha512-BSx/O0Z0SXOF5tY0bNTBcDEKz2Ec20GVYvq/H/XNKiUorUFilH7NPbFUuiiyzWaSdN3PA8JV0OvYx0gH/5aFAQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
+      "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.37.0",
-        "@typescript-eslint/utils": "5.37.0",
+        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/utils": "5.39.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.37.0.tgz",
-      "integrity": "sha512-3frIJiTa5+tCb2iqR/bf7XwU20lnU05r/sgPJnRpwvfZaqCJBrl8Q/mw9vr3NrNdB/XtVyMA0eppRMMBqdJ1bA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
+      "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.37.0.tgz",
-      "integrity": "sha512-JkFoFIt/cx59iqEDSgIGnQpCTRv96MQnXCYvJi7QhBC24uyuzbD8wVbajMB1b9x4I0octYFJ3OwjAwNqk1AjDA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
+      "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/visitor-keys": "5.37.0",
+        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/visitor-keys": "5.39.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2188,26 +2190,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.37.0.tgz",
-      "integrity": "sha512-jUEJoQrWbZhmikbcWSMDuUSxEE7ID2W/QCV/uz10WtQqfOuKZUqFGjqLJ+qhDd17rjgp+QJPqTdPIBWwoob2NQ==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
+      "integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.37.0",
-        "@typescript-eslint/types": "5.37.0",
-        "@typescript-eslint/typescript-estree": "5.37.0",
+        "@typescript-eslint/scope-manager": "5.39.0",
+        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.39.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.37.0.tgz",
-      "integrity": "sha512-Hp7rT4cENBPIzMwrlehLW/28EVCOcE9U1Z1BQTc8EA8v5qpr7GRGuG+U58V5tTY48zvUOA3KHvw3rA8tY9fbdA==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
+      "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.37.0",
+        "@typescript-eslint/types": "5.39.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -2406,13 +2408,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.23.0.tgz",
-      "integrity": "sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.24.0.tgz",
+      "integrity": "sha512-dWFaPhGhTAiPcCgm3f6LI2MBWbogMnTJzFBbhXVRQDJPkr9pGZvVjlVfXd+vyDcWPA2Ic9L2AXPIQM0+vk/cSQ==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.1",
-        "@humanwhocodes/config-array": "^0.10.4",
+        "@eslint/eslintrc": "^1.3.2",
+        "@humanwhocodes/config-array": "^0.10.5",
         "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
         "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
@@ -2430,7 +2432,6 @@
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
-        "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
         "globals": "^13.15.0",
         "globby": "^11.1.0",
@@ -2439,6 +2440,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
+        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
@@ -2567,9 +2569,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2656,9 +2658,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -2674,12 +2676,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
     "glob": {
@@ -2820,6 +2816,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "js-sdsl": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
+      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
       "dev": true
     },
     "js-yaml": {
@@ -3085,26 +3087,18 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "devOptional": true,
       "requires": {
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "devOptional": true
-        }
+        "tslib": "^2.1.0"
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -3208,9 +3202,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^18.8.3",
-    "@typescript-eslint/eslint-plugin": "^5.39.0",
-    "@typescript-eslint/parser": "^5.39.0",
-    "eslint": "^8.24.0",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
+    "eslint": "^8.25.0",
     "husky": "^8.0.1",
     "rxjs": "^7.5.7",
     "typescript": "^4.8.4"
@@ -59,11 +59,11 @@
     "rxjs": "^6.6.7 || ^7.5.7"
   },
   "optionalDependencies": {
-    "@awesome-cordova-plugins/core": "^5.45.0",
-    "@awesome-cordova-plugins/http": "^5.45.0",
-    "@awesome-cordova-plugins/in-app-browser": "^5.45.0",
-    "@awesome-cordova-plugins/safari-view-controller": "^5.45.0",
-    "@awesome-cordova-plugins/secure-storage": "^5.45.0",
+    "@awesome-cordova-plugins/core": "^5.46.0",
+    "@awesome-cordova-plugins/http": "^5.46.0",
+    "@awesome-cordova-plugins/in-app-browser": "^5.46.0",
+    "@awesome-cordova-plugins/safari-view-controller": "^5.46.0",
+    "@awesome-cordova-plugins/secure-storage": "^5.46.0",
     "@capacitor/browser": "^4.0.1",
     "@capacitor/core": "^4.3.0",
     "@capacitor/preferences": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,13 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.36.1",
-    "@typescript-eslint/parser": "^5.36.1",
-    "eslint": "^8.23.0",
+    "@types/node": "^18.8.3",
+    "@typescript-eslint/eslint-plugin": "^5.39.0",
+    "@typescript-eslint/parser": "^5.39.0",
+    "eslint": "^8.24.0",
     "husky": "^8.0.1",
-    "rxjs": "^6.6.7",
-    "typescript": "^4.8.2"
+    "rxjs": "^7.5.7",
+    "typescript": "^4.8.4"
   },
   "files": [
     "lib/**/*"
@@ -55,17 +56,17 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "rxjs": "^6.6.7"
+    "rxjs": "^6.6.7 || ^7.5.7"
   },
   "optionalDependencies": {
+    "@awesome-cordova-plugins/core": "^5.45.0",
+    "@awesome-cordova-plugins/http": "^5.45.0",
+    "@awesome-cordova-plugins/in-app-browser": "^5.45.0",
+    "@awesome-cordova-plugins/safari-view-controller": "^5.45.0",
+    "@awesome-cordova-plugins/secure-storage": "^5.45.0",
     "@capacitor/browser": "^4.0.1",
-    "@capacitor/core": "^4.1.0",
+    "@capacitor/core": "^4.3.0",
     "@capacitor/preferences": "^4.0.1",
-    "@ionic-native/core": "^5.36.0",
-    "@ionic-native/http": "^5.36.0",
-    "@ionic-native/in-app-browser": "^5.36.0",
-    "@ionic-native/safari-view-controller": "^5.36.0",
-    "@ionic-native/secure-storage": "^5.36.0",
     "@ionic/storage": "^3.0.6",
     "capacitor-secure-storage-plugin": "^0.8.0"
   }

--- a/src/capacitor/capacitor-storage.ts
+++ b/src/capacitor/capacitor-storage.ts
@@ -4,30 +4,30 @@ import { Preferences } from '@capacitor/preferences';
 export class CapacitorStorage implements StorageBackend {
 
   async getItem(name: string): Promise<string | null> {
-    if(!Storage)
-      throw new Error("Capacitor Storage Is Undefined!");
+    if(!Preferences)
+      throw new Error("Capacitor Preferences Is Undefined!");
 
     const returned = await Preferences.get({ key: name });
     return returned.value;
   }
 
   removeItem(name: string): Promise<void> {
-    if(!Storage)
-      throw new Error("Capacitor Storage Is Undefined!");
+    if(!Preferences)
+      throw new Error("Capacitor Preferences Is Undefined!");
 
     return Preferences.remove({ key: name });
   }
 
   clear(): Promise<void> {
-    if(!Storage)
-      throw new Error("Capacitor Storage Is Undefined!");
+    if(!Preferences)
+      throw new Error("Capacitor Preferences Is Undefined!");
 
     return Preferences.clear();
   }
 
   setItem(name: string, value: string): Promise<void> {
-    if(!Storage)
-      throw new Error("Capacitor Storage Is Undefined!");
+    if(!Preferences)
+      throw new Error("Capacitor Preferences Is Undefined!");
 
     return  Preferences.set({ key: name, value: value });
   }

--- a/src/cordova/cordova-browser.ts
+++ b/src/cordova/cordova-browser.ts
@@ -1,7 +1,7 @@
 import { CordovaDocument } from './cordova-document';
 import { Browser } from '../auth-browser'
-import { SafariViewController } from '@ionic-native/safari-view-controller'
-import { InAppBrowser, InAppBrowserObject } from '@ionic-native/in-app-browser'
+import { SafariViewController } from '@awesome-cordova-plugins/safari-view-controller'
+import { InAppBrowser, InAppBrowserObject } from '@awesome-cordova-plugins/in-app-browser'
 
 // REQUIRES CORDOVA PLUGINS
 // cordova-plugin-safariviewcontroller

--- a/src/cordova/cordova-requestor.ts
+++ b/src/cordova/cordova-requestor.ts
@@ -1,6 +1,6 @@
 import { CordovaDocument } from './cordova-document';
 import { Requestor } from '@openid/appauth';
-import { HTTP, HTTPResponse } from '@ionic-native/http'
+import { HTTP, HTTPResponse } from '@awesome-cordova-plugins/http'
 
 export interface XhrSettings {
     url: string,

--- a/src/cordova/cordova-secure-storage.ts
+++ b/src/cordova/cordova-secure-storage.ts
@@ -1,6 +1,6 @@
 import { CordovaDocument } from './cordova-document';
 import { StorageBackend } from '@openid/appauth';
-import { SecureStorage, SecureStorageObject } from '@ionic-native/secure-storage'
+import { SecureStorage, SecureStorageObject } from '@awesome-cordova-plugins/secure-storage'
 
 // REQUIRES CORDOVA PLUGINS
 // cordova-plugin-secure-storage


### PR DESCRIPTION
This PR also allows RxJS 7!
@ionic-native/core has a peer dependency on old RxJS versions, thats why dependabot's build is failing:
`peer rxjs@"^5.5.0 || ^6.5.0" from @ionic-native/core@5.36.0`

@awesome-cordova-plugins/core fixes that