### PR TITLE
White screen

### DIFF
--- a/demos/angular-capacitor/browserslist
+++ b/demos/angular-capacitor/browserslist
@@ -5,8 +5,8 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-> 0.5%
-last 2 versions
-Firefox ESR
-not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.
+Chrome >=60
+Firefox >=63
+Edge >=79
+Safari >=13
+iOS >=13


### PR DESCRIPTION
Ionic 6 default project white screen on Android 30 or below when using –prod

https://forum.ionicframework.com/t/ionic-6-default-project-white-screen-on-android-30-or-below-when-using-prod/228087/18