### PR TITLE
Fix: replace guid with uuid

### DIFF
--- a/lib/auth-observer.d.ts
+++ b/lib/auth-observer.d.ts
@@ -1,9 +1,8 @@
 import { IAuthAction } from './auth-action';
 import { TokenResponse } from '@openid/appauth';
-import { Guid } from 'guid-typescript';
 import { IAuthSession } from './auth-session';
 export declare abstract class BaseAuthObserver {
-  protected id: Guid;
+  protected id: string;
   abstract update(action: IAuthAction): void;
 }
 export declare class AuthObserver extends BaseAuthObserver {

--- a/lib/auth-observer.js
+++ b/lib/auth-observer.js
@@ -1,9 +1,9 @@
 import { AuthActions } from './auth-action';
-import { Guid } from 'guid-typescript';
+import { v4 as uuidv4 } from 'uuid';
 import { DefaultAuthSession } from './auth-session';
 export class BaseAuthObserver {
   constructor() {
-    this.id = Guid.create();
+    this.id = uuidv4();
   }
 }
 export class AuthObserver extends BaseAuthObserver {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,15 @@
       "dependencies": {
         "@openid/appauth": "^1.3.1",
         "@types/chai-as-promised": "^7.1.5",
-        "guid-typescript": "^1.0.9",
-        "tslib": "^2.5.0"
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@types/chai": "^4.3.4",
         "@types/mocha": "^10.0.1",
         "@types/node": "^20.1.4",
+        "@types/uuid": "^9.0.4",
         "@typescript-eslint/eslint-plugin": "^5.58.0",
         "@typescript-eslint/parser": "^5.40.0",
         "chai": "^4.3.7",
@@ -1058,6 +1059,12 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.4.tgz",
+      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.60.0",
@@ -2850,11 +2857,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/guid-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
-      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
-    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -3229,6 +3231,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -5049,10 +5060,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -6070,6 +6084,12 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
+    },
+    "@types/uuid": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.4.tgz",
+      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.60.0",
@@ -7320,11 +7340,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "guid-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
-      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7599,6 +7614,14 @@
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-report": {
@@ -8979,10 +9002,9 @@
       }
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/chai": "^4.3.4",
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.1.4",
+    "@types/uuid": "^9.0.4",
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.40.0",
     "chai": "^4.3.7",
@@ -68,8 +69,8 @@
   "dependencies": {
     "@openid/appauth": "^1.3.1",
     "@types/chai-as-promised": "^7.1.5",
-    "guid-typescript": "^1.0.9",
-    "tslib": "^2.5.0"
+    "tslib": "^2.5.0",
+    "uuid": "^9.0.1"
   },
   "peerDependencies": {
     "rxjs": "^7.5.7 || ^7.8.0"

--- a/src/auth-observer.ts
+++ b/src/auth-observer.ts
@@ -1,10 +1,10 @@
 import { IAuthAction, AuthActions } from './auth-action';
 import { TokenResponse } from '@openid/appauth';
-import { Guid } from 'guid-typescript';
+import { v4 as uuidv4 } from 'uuid';
 import { DefaultAuthSession, IAuthSession } from './auth-session';
 
 export abstract class BaseAuthObserver {
-  protected id: Guid = Guid.create();
+  protected id = uuidv4();
   abstract update(action: IAuthAction): void;
 }
 


### PR DESCRIPTION
Removes the build warning 'ionic-appauth/lib/auth-observer.js depends on 'guid-typescript'. CommonJS or AMD dependencies can cause optimization bailouts.'
fixes #130 