### PR TITLE
Add initialization check for signing

### DIFF
--- a/src/auth-service.ts
+++ b/src/auth-service.ts
@@ -54,6 +54,7 @@ export class AuthService implements IAuthService {
   private _authSubject: AuthSubject = new AuthSubject();
   private _actionHistory: ActionHistoryObserver = new ActionHistoryObserver();
   private _session: SessionObserver = new SessionObserver();
+  private _notifier: AuthorizationNotifier | undefined = undefined;
 
   private _authSubjectV2 = new BehaviorSubject<IAuthAction>(AuthActionBuilder.Init());
   private _tokenSubject = new BehaviorSubject<TokenResponse>(undefined);
@@ -191,6 +192,7 @@ export class AuthService implements IAuthService {
     let notifier = new AuthorizationNotifier();
     this.requestHandler.setAuthorizationNotifier(notifier);
     notifier.setAuthorizationListener((request, response, error) => this.onAuthorizationNotification(request, response, error));
+    this._notifier = notifier;
   }
 
   protected onAuthorizationNotification(
@@ -342,7 +344,7 @@ export class AuthService implements IAuthService {
   }
 
   public async signIn(authExtras?: StringMap, state?: string) {
-    if (!this._initComplete.value) {
+    if (!this._notifier) {
       throw new Error('Trying to sign in before AuthService is initialized!');
     }
     

--- a/src/auth-service.ts
+++ b/src/auth-service.ts
@@ -342,6 +342,10 @@ export class AuthService implements IAuthService {
   }
 
   public async signIn(authExtras?: StringMap, state?: string) {
+    if (!this._initComplete.value) {
+      throw new Error('Trying to sign in before AuthService is initialized!');
+    }
+    
     await this.performAuthorizationRequest(authExtras, state).catch((response) => {
       this.notifyActionListers(AuthActionBuilder.SignInFailed(response));
     });


### PR DESCRIPTION
If the initialization is not complete when trying to sign in, the response from the identity-provider will be "lost" because no `Notifier` is registered with the @openid/appauth code.

This will lead to an infinite wait for the result of the login. That is quite time-consuming to debug. Therefore, an error should make things a lot easier for the programmer.

Maybe you can think of a more elegant solution. My point is just that there should be some mechanism to tell the developer that the service was used before being initialized...