### PR TITLE
Make sure that AuthService.init() is always executed

### DIFF
--- a/demos/angular-capacitor/src/app/app.module.ts
+++ b/demos/angular-capacitor/src/app/app.module.ts
@@ -19,7 +19,12 @@ import { CoreModule } from './core/core.module';
     CoreModule
   ],
   providers: [
-    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy }
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (authService: AuthService) => authService.init(),
+      deps: [AuthService]
+    },
   ],
   bootstrap: [AppComponent]
 })

--- a/demos/angular-capacitor/src/app/app.module.ts
+++ b/demos/angular-capacitor/src/app/app.module.ts
@@ -1,13 +1,13 @@
-import { NgModule } from '@angular/core';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { RouteReuseStrategy } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
-
 import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { CoreModule } from './core/core.module';
+import {AuthService} from "../../../../lib";
 
 @NgModule({
   declarations: [AppComponent],


### PR DESCRIPTION
Similar topic as already discussed: If AuthService.init() is not executed before a login-flow is started, the login-flow never completes because no listener is registered with the @openid/appauth logic. In that case, debugging is very time-consuming because no helpful logging is provided.

With this app-initializer logic of angular, we can be sure that the service is initialized before the UI-components are loaded.